### PR TITLE
Add one-time installation script and Brewfile

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -31,7 +31,7 @@ if ! command -v oh-my-posh > /dev/null; then
   # oh-my-posh not found, try to install with brew
   if command -v brew > /dev/null; then
     echo "Attempting to install oh-my-posh using Homebrew..."
-    brew install oh-my-posh
+    brew install jandedobbeleer/oh-my-posh/oh-my-posh # <-- This line is updated
   else
     echo "oh-my-posh not found, and Homebrew is not available to install it."
   fi

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,15 @@
+# Brewfile for silverAndroid/.files
+
+# Shell essentials & theming
+brew "jandedobbeleer/oh-my-posh/oh-my-posh"
+brew "fzf"
+brew "zoxide"
+
+# Development version managers
+brew "nvm"
+
+# Java Development Kit
+brew "openjdk@23"
+
+# Build tools
+brew "bazelisk"

--- a/README.md
+++ b/README.md
@@ -1,18 +1,55 @@
 # .files
 
-Contains my dotfiles that I sync via [Stow](https://www.gnu.org/software/stow/)
+Contains my dotfiles that I sync via [Stow](https://www.gnu.org/software/stow/).
 
-## Installation
+## Automated Installation (Recommended)
 
-* Install [Stow](https://www.gnu.org/software/stow/) if you haven't already
-* Clone this repo
-```bash
-git clone https://github.com/silverAndroid/.files ~/dotfiles
-```
+This repository now includes an automated installation script (`install.sh`) that handles all necessary setup steps.
 
-## Usage
+To use the script:
 
-```bash
-cd ~/dotfiles
-stow .
-```
+1.  **Clone this repository to your desired location (typically `~/dotfiles`):**
+    ```bash
+    git clone https://github.com/silverAndroid/.files ~/dotfiles
+    ```
+    (If you choose a different location than `~/dotfiles`, `stow` will still link files relative to that location's parent directory. For example, cloning to `~/mydots` would have `stow` link to `~`.)
+
+2.  **Navigate into the cloned repository's directory:**
+    ```bash
+    cd ~/dotfiles 
+    # Or cd to the custom location you used
+    ```
+
+3.  **Run the installation script:**
+    ```bash
+    ./install.sh
+    ```
+
+The script will:
+*   Check for and install [Homebrew](https://brew.sh/) if it's not already present.
+*   Install required software packages listed in the local `Brewfile` (e.g., `oh-my-posh`, `fzf`, `nvm`, etc.).
+    *   Note: `oh-my-posh` is installed via its official tap `jandedobbeleer/oh-my-posh/oh-my-posh`.
+*   Check for and install [Stow](https://www.gnu.org/software/stow/) if it's not already present.
+*   Run `stow .` from within the repository's root directory to create symbolic links (typically to your home directory, if you cloned to `~/dotfiles`).
+
+## Manual Installation
+
+If you prefer to set things up manually, you will need to:
+
+1.  Ensure [Homebrew](https://brew.sh/) is installed.
+2.  Install packages: You can inspect the `Brewfile` and install the listed packages (e.g., `oh-my-posh`, `fzf`, `stow`) using `brew install <package>` or `brew bundle install`.
+3.  Ensure [Stow](https://www.gnu.org/software/stow/) is installed.
+4.  Clone this repository to `~/dotfiles`:
+    ```bash
+    git clone https://github.com/silverAndroid/.files ~/dotfiles
+    ```
+5.  Navigate into the directory and run Stow:
+    ```bash
+    cd ~/dotfiles
+    stow .
+    ```
+
+## Software Management
+
+*   Core software dependencies are managed via Homebrew and are listed in the `Brewfile`.
+*   Zsh plugins are managed by `zinit` as configured in `.zshrc`.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+#
+# Installation script for silverAndroid/.files
+#
+# This script will:
+# 1. Check for and install Homebrew if not present.
+# 2. Install packages from the Brewfile.
+# 3. Check for and install Stow if not present.
+# 4. Run stow to link the dotfiles from the current directory.
+
+echo "Starting installation for silverAndroid/.files..."
+
+# --- Check and Install Homebrew ---
+echo "Checking for Homebrew..."
+if ! command -v brew &> /dev/null; then
+    echo "Homebrew not found. Installing Homebrew..."
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    
+    # Attempt to add Homebrew to PATH for the current script execution
+    # This depends on the OS and where Homebrew installs.
+    # For macOS (Apple Silicon):
+    if [ -x "/opt/homebrew/bin/brew" ]; then
+        echo "Adding Homebrew (Apple Silicon) to PATH for this session..."
+        eval "$(/opt/homebrew/bin/brew shellenv)"
+    fi
+    # For macOS (Intel) & Linux:
+    if [ -x "/usr/local/bin/brew" ]; then
+        echo "Adding Homebrew (Intel macOS/Linux) to PATH for this session..."
+        eval "$(/usr/local/bin/brew shellenv)"
+    fi
+    # For Linuxbrew in specific home directory:
+    if [ -f "/home/linuxbrew/.linuxbrew/bin/brew" ]; then
+        echo "Adding Homebrew (Linuxbrew) to PATH for this session..."
+        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+    fi
+
+    if ! command -v brew &> /dev/null; then
+        echo "ERROR: Homebrew installation failed or brew is still not in PATH."
+        echo "Please install Homebrew manually and re-run this script."
+        exit 1
+    else
+        echo "Homebrew installed successfully."
+    fi
+else
+    echo "Homebrew is already installed."
+fi
+# --- End Homebrew Check ---
+
+# --- Install Packages from Brewfile ---
+echo "Installing packages from Brewfile..."
+if [ -f "./Brewfile" ]; then
+    if command -v brew &> /dev/null; then
+        echo "Using Homebrew to install packages from Brewfile..."
+        brew bundle install --file=./Brewfile
+        echo "Brewfile packages installation attempt complete."
+    else
+        echo "WARNING: Homebrew is not available, cannot install packages from Brewfile."
+    fi
+else
+    echo "WARNING: Brewfile not found in the current directory. Skipping package installation from Brewfile."
+fi
+# --- End Brewfile Package Installation ---
+
+# --- Check and Install Stow ---
+echo "Checking for Stow..."
+if ! command -v stow &> /dev/null; then
+    echo "Stow not found. Attempting to install Stow using Homebrew..."
+    if command -v brew &> /dev/null; then
+        brew install stow
+        if ! command -v stow &> /dev/null; then
+            echo "ERROR: Stow installation failed even with Homebrew."
+            echo "Please install Stow manually and re-run this script."
+            exit 1
+        else
+            echo "Stow installed successfully via Homebrew."
+        fi
+    else
+        echo "ERROR: Homebrew is not available, and Stow is not installed."
+        echo "Please install Homebrew and Stow manually, then re-run this script."
+        exit 1
+    fi
+else
+    echo "Stow is already installed."
+fi
+# --- End Stow Check ---
+
+# --- Run Stow ---
+echo "Running Stow to link dotfiles from the current directory ($(pwd))..."
+
+if ! command -v stow &> /dev/null; then
+    echo "ERROR: Stow command not found. Stow installation may have failed or was skipped."
+    echo "Please ensure Stow is installed and in your PATH."
+elif [ ! -f ".stow-config" ] && [ ! -d ".git" ]; then # Basic check if this looks like the dotfiles repo
+    echo "WARNING: Current directory ($(pwd)) might not be the root of the dotfiles repository (missing .git or .stow-config)."
+    echo "Please ensure you are running this script from the root of your dotfiles clone."
+    read -r -p "Proceed with 'stow .' in the current directory? (y/N): " confirm_stow
+    if [[ ! "$confirm_stow" =~ ^[yY](es)?$ ]]; then
+        echo "Stow operation cancelled by user."
+    else
+        echo "Proceeding with 'stow .' in $(pwd)..."
+        stow .
+        if [ $? -ne 0 ]; then
+            echo "ERROR: Stow command failed. Please check for conflicts or issues."
+        else
+            echo "Stow command completed successfully."
+        fi
+    fi
+else
+    stow .
+    if [ $? -ne 0 ]; then
+        echo "ERROR: Stow command failed. Please check for conflicts or issues in $(pwd)."
+    else
+        echo "Stow command completed successfully."
+    fi
+fi
+# --- End Run Stow ---
+
+# (Rest of the script will follow)


### PR DESCRIPTION
Introduces an automated installation script (`install.sh`) to streamline the setup of your dotfiles environment.

Key changes include:

- **`install.sh`**: A new bash script that:
    - Checks for and installs Homebrew.
    - Installs software packages listed in the `Brewfile` using `brew bundle`.
    - Checks for and installs Stow.
    - Runs `stow .` to symbolically link the dotfiles.
    - Includes error handling and prompts for you where necessary.
- **`Brewfile`**: A new file listing Homebrew dependencies such as
  `oh-my-posh`, `fzf`, `zoxide`, `nvm`, `openjdk@23`, and `bazelisk`.
  `oh-my-posh` is configured to install from the official tap
  `jandedobbeleer/oh-my-posh/oh-my-posh`.
- **`.zshrc`**: Updated the fallback `oh-my-posh` installation command
  to use the official tap `jandedobbeleer/oh-my-posh/oh-my-posh`.
- **`README.md`**: Overhauled the installation instructions to feature
  the new `install.sh` script as the recommended setup method.
  Manual installation steps are preserved for reference. Information
  about software management via Homebrew/Brewfile and Zinit has been added.

The `install.sh` script is marked as executable.