### PR TITLE
refactor: Remove usage of Brewfile from install script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ To use the script:
 
 The script will:
 *   Check for and install [Homebrew](https://brew.sh/) if it's not already present.
-*   Install required software packages listed in the local `Brewfile` (e.g., `oh-my-posh`, `fzf`, `nvm`, etc.).
-    *   Note: `oh-my-posh` is installed via its official tap `jandedobbeleer/oh-my-posh/oh-my-posh`.
+*   Install required software packages (e.g., `oh-my-posh`, `fzf`, `zoxide`, etc.) using Homebrew.
 *   Check for and install [Stow](https://www.gnu.org/software/stow/) if it's not already present.
 *   Run `stow .` from within the repository's root directory to create symbolic links (typically to your home directory, if you cloned to `~/dotfiles`).
 
@@ -37,7 +36,7 @@ The script will:
 If you prefer to set things up manually, you will need to:
 
 1.  Ensure [Homebrew](https://brew.sh/) is installed.
-2.  Install packages: You can inspect the `Brewfile` and install the listed packages (e.g., `oh-my-posh`, `fzf`, `stow`) using `brew install <package>` or `brew bundle install`.
+2.  Install packages: You can inspect the `install.sh` script to see the list of packages to install (e.g., `fzf`, `zoxide`, `stow`) and install them using `brew install <package>`.
 3.  Ensure [Stow](https://www.gnu.org/software/stow/) is installed.
 4.  Clone this repository to `~/dotfiles`:
     ```bash
@@ -51,5 +50,5 @@ If you prefer to set things up manually, you will need to:
 
 ## Software Management
 
-*   Core software dependencies are managed via Homebrew and are listed in the `Brewfile`.
+*   Core software dependencies are managed via Homebrew and are installed by the `install.sh` script.
 *   Zsh plugins are managed by `zinit` as configured in `.zshrc`.

--- a/install.sh
+++ b/install.sh
@@ -47,23 +47,19 @@ else
 fi
 # --- End Homebrew Check ---
 
-# --- Install Packages from Brewfile ---
-echo "Installing packages from Brewfile..."
-if [ -f "./Brewfile" ]; then
-    if command -v brew &> /dev/null; then
-        echo "Using Homebrew to install packages from Brewfile..."
-        brew install fzf
-        brew install zoxide
-        brew install "openjdk@23"
-        brew install bazelisk
-        echo "Brewfile packages installation attempt complete."
-    else
-        echo "WARNING: Homebrew is not available, cannot install packages from Brewfile."
-    fi
+# --- Install Homebrew Packages ---
+echo "Installing Homebrew packages..."
+if command -v brew &> /dev/null; then
+    echo "Using Homebrew to install packages..."
+    brew install fzf
+    brew install zoxide
+    brew install "openjdk@23"
+    brew install bazelisk
+    echo "Homebrew package installation attempt complete."
 else
-    echo "WARNING: Brewfile not found in the current directory. Skipping package installation from Brewfile."
+    echo "WARNING: Homebrew is not available, cannot install packages."
 fi
-# --- End Brewfile Package Installation ---
+# --- End Homebrew Package Installation ---
 
 # --- Install Oh My Posh ---
 # Install unzip on Ubuntu, as it is required by oh-my-posh installer


### PR DESCRIPTION
The Brewfile is no longer used for package management.

This change removes all references to it from the `install.sh` script and the `README.md` documentation. The installation script now calls `brew install` directly for the required packages.

The `Brewfile` itself was not present in the repository, so only the references were removed.