### PR TITLE
refactor: Move installation commands to install.sh

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -19,11 +19,6 @@ ZINIT_HOME="${XDG_DATA_HOME:-${HOME}/.local/share}/zinit/zinit.git"
 export PATH=$PATH:$(brew --prefix)/bin
 export PATH=$PATH:/home/ruru/.local/bin
 
-# Download Zinit, if it's not there yet
-if [ ! -d "$ZINIT_HOME" ]; then
-   bash -c "$(curl --fail --show-error --silent --location https://raw.githubusercontent.com/zdharma-continuum/zinit/HEAD/scripts/install.sh)"
-fi
-
 # Source/Load zinit
 source "${ZINIT_HOME}/zinit.zsh"
 
@@ -83,21 +78,11 @@ alias ls='ls --color'
 alias c='clear'
 
 # Shell integrations
-if ! command -v fzf > /dev/null; then
-  if command -v brew > /dev/null; then
-    brew install fzf
-  fi
-fi
 # Ensure fzf is sourced only if available
 if command -v fzf > /dev/null; then
   source <(fzf --zsh)
 fi
 
-if ! command -v zoxide > /dev/null; then
-  if command -v brew > /dev/null; then
-    brew install zoxide
-  fi
-fi
 # Ensure zoxide is initialized only if available
 if command -v zoxide > /dev/null; then
   eval "$(zoxide init --cmd cd zsh)"
@@ -116,16 +101,6 @@ export PATH=$PATH:$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$ANDROID_H
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
-# nvm
-if ! command -v nvm > /dev/null; then
-  if command -v brew > /dev/null; then
-    brew install nvm
-  else
-    echo "Installing nvm via curl..."
-    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
-  fi
-fi
-
 # java
 if command -v brew > /dev/null && brew list openjdk@23 > /dev/null 2>&1; then
   # If openjdk@23 is installed via brew, set JAVA_HOME to its prefix
@@ -136,23 +111,6 @@ elif [[ -d "/opt/homebrew/opt/openjdk@23" ]]; then # Fallback for existing manua
   export PATH=$JAVA_HOME/bin:$PATH
 fi
 
-
-# Bazelisk
-if ! command -v bazel > /dev/null; then
-  if command -v brew > /dev/null; then
-    brew install bazelisk
-  fi
-  if ! command -v bazel > /dev/null; then # If brew install failed or brew is not available
-      echo "Installing Bazelisk via curl..."
-      curl -fsSL https://github.com/bazelbuild/bazelisk/releases/download/v1.18.0/bazelisk-1.18.0.tar.gz -o /tmp/bazelisk-1.18.0.tar.gz
-      tar -xf /tmp/bazelisk-1.18.0.tar.gz
-      chmod +x /tmp/bazelisk-1.18.0
-      mv /tmp/bazelisk-1.18.0 "$HOME/bin/bazelisk"
-      rm /tmp/bazelisk-1.18.0.tar.gz
-      echo "Bazelisk installed successfully!"
-  fi
-  export PATH="$HOME/bin/bazelisk:$PATH"
-fi
 
 # Load a few important annexes, without Turbo
 # (this is currently required for annexes)

--- a/install.sh
+++ b/install.sh
@@ -61,11 +61,47 @@ if command -v brew &> /dev/null; then
     brew install zoxide
     brew install "openjdk@23"
     brew install bazelisk
+    brew install nvm
     echo "Homebrew package installation attempt complete."
 else
     echo "WARNING: Homebrew is not available, cannot install packages."
 fi
 # --- End Homebrew Package Installation ---
+
+# --- Install Fallbacks & Other Tools ---
+
+# Bazelisk
+if ! command -v bazel > /dev/null; then
+    echo "Installing Bazelisk via curl as fallback..."
+    curl -fsSL https://github.com/bazelbuild/bazelisk/releases/download/v1.18.0/bazelisk-1.18.0.tar.gz -o /tmp/bazelisk-1.18.0.tar.gz
+    tar -xf /tmp/bazelisk-1.18.0.tar.gz
+    chmod +x /tmp/bazelisk-1.18.0
+    mkdir -p "$HOME/bin"
+    mv /tmp/bazelisk-1.18.0 "$HOME/bin/bazelisk"
+    rm /tmp/bazelisk-1.18.0.tar.gz
+    echo "Bazelisk installed successfully!"
+fi
+
+# NVM
+if ! command -v nvm > /dev/null; then
+    echo "Installing nvm via curl as fallback..."
+    export NVM_DIR="$HOME/.nvm"
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+fi
+# Create nvm directory, the nvm installer might create it, but -p makes it safe
+mkdir -p "$HOME/.nvm"
+
+# Zinit
+echo "Installing Zinit..."
+ZINIT_HOME="${XDG_DATA_HOME:-${HOME}/.local/share}/zinit/zinit.git"
+if [ ! -d "$ZINIT_HOME" ]; then
+   bash -c "$(curl --fail --show-error --silent --location https://raw.githubusercontent.com/zdharma-continuum/zinit/HEAD/scripts/install.sh)"
+   echo "Zinit installed."
+else
+   echo "Zinit is already installed."
+fi
+
+# --- End Fallbacks & Other Tools ---
 
 # --- Ubuntu Specific Setup ---
 if is_ubuntu; then


### PR DESCRIPTION
Move installation logic for zinit, fzf, zoxide, nvm, and bazelisk from .zshrc to install.sh.

This centralizes the installation logic in one script and cleans up the .zshrc file, so it can focus on shell configuration and environment setup.

The install.sh script is now responsible for:
- Installing brew and brew packages.
- Providing curl-based fallbacks for key tools if brew is not available or fails.
- Installing zinit.

The .zshrc file is now simpler and only sources the necessary configurations and sets up the shell environment.