### PR TITLE
feat: Set up Dockerfile and GHCR for VPS deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.github
+.vscode
+README.md
+GEMINI.md

--- a/.github/workflows/docker-build-check.yml
+++ b/.github/workflows/docker-build-check.yml
@@ -1,0 +1,31 @@
+name: Docker Build
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          tags: ghcr.io/${{ github.repository }}/pr-${{ github.event.number }}:latest
+          cache-from: type=gha,scope=${{ github.workflow }}
+          cache-to: type=gha,scope=${{ github.workflow }},mode=max

--- a/.github/workflows/docker-build-check.yml
+++ b/.github/workflows/docker-build-check.yml
@@ -21,11 +21,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set lowercase repository name
+        id: repo
+        run: echo "name=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
+
       - name: Build Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
           push: false
-          tags: ghcr.io/${{ toLower(github.repository) }}/pr-${{ github.event.number }}:latest
+          tags: ghcr.io/${{ steps.repo.outputs.name }}/pr-${{ github.event.number }}:latest
           cache-from: type=gha,scope=${{ github.workflow }}
           cache-to: type=gha,scope=${{ github.workflow }},mode=max

--- a/.github/workflows/docker-build-check.yml
+++ b/.github/workflows/docker-build-check.yml
@@ -26,6 +26,6 @@ jobs:
         with:
           context: .
           push: false
-          tags: ghcr.io/${{ github.repository }}/pr-${{ github.event.number }}:latest
+          tags: ghcr.io/${{ toLower(github.repository) }}/pr-${{ github.event.number }}:latest
           cache-from: type=gha,scope=${{ github.workflow }}
           cache-to: type=gha,scope=${{ github.workflow }},mode=max

--- a/.github/workflows/docker-build-check.yml
+++ b/.github/workflows/docker-build-check.yml
@@ -21,9 +21,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set lowercase repository name
+      - name: Set Docker image name
         id: repo
-        run: echo "name=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
+        run: |
+          repo_lower=${GITHUB_REPOSITORY,,}
+          echo "name=${repo_lower/.files/dotfiles}" >> $GITHUB_OUTPUT
 
       - name: Build Docker image
         uses: docker/build-push-action@v6

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,18 +12,20 @@ jobs:
       packages: write
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
 
     - name: Log in to the Container registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v6
       with:
         context: .
         push: true
-        tags: ghcr.io/${{ github.repository }}:latest
+        tags: |
+          ghcr.io/${{ github.repository }}:latest
+          ghcr.io/${{ github.repository }}:${{ github.sha }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,13 +21,15 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Set lowercase repository name
+      id: repo
+      run: echo "name=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
+
     - name: Build and push Docker image
       uses: docker/build-push-action@v6
       with:
         context: .
         push: true
-        tags: |
-          ghcr.io/${{ toLower(github.repository) }}:latest
-          ghcr.io/${{ toLower(github.repository) }}:${{ github.sha }}
+        tags: ghcr.io/${{ steps.repo.outputs.name }}:latest,ghcr.io/${{ steps.repo.outputs.name }}:${{ github.sha }}
         cache-from: type=gha,scope=${{ github.workflow }}
         cache-to: type=gha,scope=${{ github.workflow }},mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,29 @@
+name: Docker Publish
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Log in to the Container registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        push: true
+        tags: ghcr.io/${{ github.repository }}:latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,3 +29,5 @@ jobs:
         tags: |
           ghcr.io/${{ github.repository }}:latest
           ghcr.io/${{ github.repository }}:${{ github.sha }}
+        cache-from: type=gha,scope=${{ github.workflow }}
+        cache-to: type=gha,scope=${{ github.workflow }},mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,9 +21,11 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Set lowercase repository name
+    - name: Set Docker image name
       id: repo
-      run: echo "name=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
+      run: |
+        repo_lower=${GITHUB_REPOSITORY,,}
+        echo "name=${repo_lower/.files/dotfiles}" >> $GITHUB_OUTPUT
 
     - name: Build and push Docker image
       uses: docker/build-push-action@v6

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -27,7 +27,7 @@ jobs:
         context: .
         push: true
         tags: |
-          ghcr.io/${{ github.repository }}:latest
-          ghcr.io/${{ github.repository }}:${{ github.sha }}
+          ghcr.io/${{ toLower(github.repository) }}:latest
+          ghcr.io/${{ toLower(github.repository) }}:${{ github.sha }}
         cache-from: type=gha,scope=${{ github.workflow }}
         cache-to: type=gha,scope=${{ github.workflow }},mode=max

--- a/.zshrc
+++ b/.zshrc
@@ -102,12 +102,12 @@ export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 # java
-if command -v brew > /dev/null && brew list openjdk@23 > /dev/null 2>&1; then
-  # If openjdk@23 is installed via brew, set JAVA_HOME to its prefix
-  export JAVA_HOME=$(brew --prefix openjdk@23)
+if command -v brew > /dev/null && brew list openjdk@21 > /dev/null 2>&1; then
+  # If openjdk@21 is installed via brew, set JAVA_HOME to its prefix
+  export JAVA_HOME=$(brew --prefix openjdk@21)
   export PATH=$JAVA_HOME/bin:$PATH
-elif [[ -d "/opt/homebrew/opt/openjdk@23" ]]; then # Fallback for existing manual Mac M1/M2 setups
-  export JAVA_HOME=/opt/homebrew/opt/openjdk@23
+elif [[ -d "/opt/homebrew/opt/openjdk@21" ]]; then # Fallback for existing manual Mac M1/M2 setups
+  export JAVA_HOME=/opt/homebrew/opt/openjdk@21
   export PATH=$JAVA_HOME/bin:$PATH
 fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,12 +31,6 @@ ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}
 # Install packages with Homebrew
 RUN brew install fzf zoxide "openjdk@21" bazelisk nvm stow
 
-# Install Zinit
-RUN bash -c "$(curl --fail --show-error --silent --location https://raw.githubusercontent.com/zdharma-continuum/zinit/HEAD/scripts/install.sh)"
-
-# Install Oh My Posh
-RUN curl -s https://ohmyposh.dev/install.sh | bash -s
-
 # Copy the dotfiles
 COPY --chown=user:user . /home/user/dotfiles
 
@@ -44,6 +38,12 @@ COPY --chown=user:user . /home/user/dotfiles
 WORKDIR /home/user/dotfiles
 RUN stow .
 WORKDIR /home/user
+
+# Install Zinit
+RUN bash -c "$(curl --fail --show-error --silent --location https://raw.githubusercontent.com/zdharma-continuum/zinit/HEAD/scripts/install.sh)"
+
+# Install Oh My Posh
+RUN curl -s https://ohmyposh.dev/install.sh | bash -s
 
 # Set the default shell to zsh for the user
 RUN sudo chsh -s /usr/bin/zsh user

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,14 +24,14 @@ USER user
 WORKDIR /home/user
 
 # Install Homebrew
-RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+RUN CI=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
 RUN echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /home/user/.zshrc && \
     echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /home/user/.bashrc
 
 
 # Install packages with Homebrew
-RUN brew install fzf zoxide "openjdk@23" bazelisk nvm stow
+RUN brew install fzf zoxide "openjdk@21" bazelisk nvm stow
 
 # Install Zinit
 RUN bash -c "$(curl --fail --show-error --silent --location https://raw.githubusercontent.com/zdharma-continuum/zinit/HEAD/scripts/install.sh)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y \
 # Create a non-root user and add it to the sudo group
 RUN useradd -m -s /bin/bash -G sudo user
 RUN echo "user:user" | chpasswd
+RUN echo "user ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 USER user
 WORKDIR /home/user
 
@@ -43,7 +44,9 @@ RUN curl -s https://ohmyposh.dev/install.sh | bash -s
 COPY --chown=user:user . /home/user/dotfiles
 
 # Run stow
-RUN cd dotfiles && stow .
+WORKDIR /home/user/dotfiles
+RUN stow .
+WORKDIR /home/user
 
 # Set the default shell to zsh for the user
 RUN sudo chsh -s /usr/bin/zsh user

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,6 @@ WORKDIR /home/user
 # Install Homebrew
 RUN CI=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
-RUN echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /home/user/.zshrc && \
-    echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /home/user/.bashrc
 
 
 # Install packages with Homebrew
@@ -46,6 +44,10 @@ COPY --chown=user:user . /home/user/dotfiles
 WORKDIR /home/user/dotfiles
 RUN stow .
 WORKDIR /home/user
+
+# Set up shell environment
+RUN echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /home/user/.zshrc && \
+    echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /home/user/.bashrc
 
 # Set the default shell to zsh for the user
 RUN sudo chsh -s /usr/bin/zsh user

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ RUN apt-get update && apt-get install -y \
 
 # Create a non-root user and add it to the sudo group
 RUN useradd -m -s /bin/bash -G sudo user
-RUN echo "user:user" | chpasswd
 RUN echo "user ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 USER user
 WORKDIR /home/user
@@ -27,8 +26,8 @@ WORKDIR /home/user
 # Install Homebrew
 RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
-RUN echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /home/user/.zshrc
-RUN echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /home/user/.bashrc
+RUN echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /home/user/.zshrc && \
+    echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /home/user/.bashrc
 
 
 # Install packages with Homebrew

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use Ubuntu as the base image
-FROM ubuntu:latest
+FROM ubuntu:22.04
 
 # Set non-interactive frontend for package installation
 ENV DEBIAN_FRONTEND=noninteractive
@@ -14,7 +14,8 @@ RUN apt-get update && apt-get install -y \
     sudo \
     unzip \
     zsh \
-    mosh
+    mosh \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Create a non-root user and add it to the sudo group
 RUN useradd -m -s /bin/bash -G sudo user

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,10 +45,6 @@ WORKDIR /home/user/dotfiles
 RUN stow .
 WORKDIR /home/user
 
-# Set up shell environment
-RUN echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /home/user/.zshrc && \
-    echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /home/user/.bashrc
-
 # Set the default shell to zsh for the user
 RUN sudo chsh -s /usr/bin/zsh user
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+# Use Ubuntu as the base image
+FROM ubuntu:latest
+
+# Set non-interactive frontend for package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    procps \
+    curl \
+    file \
+    git \
+    sudo \
+    unzip \
+    zsh \
+    mosh
+
+# Create a non-root user and add it to the sudo group
+RUN useradd -m -s /bin/bash -G sudo user
+RUN echo "user:user" | chpasswd
+USER user
+WORKDIR /home/user
+
+# Install Homebrew
+RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
+RUN echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /home/user/.zshrc
+RUN echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /home/user/.bashrc
+
+
+# Install packages with Homebrew
+RUN brew install fzf zoxide "openjdk@23" bazelisk nvm stow
+
+# Install Zinit
+RUN bash -c "$(curl --fail --show-error --silent --location https://raw.githubusercontent.com/zdharma-continuum/zinit/HEAD/scripts/install.sh)"
+
+# Install Oh My Posh
+RUN curl -s https://ohmyposh.dev/install.sh | bash -s
+
+# Copy the dotfiles
+COPY --chown=user:user . /home/user/dotfiles
+
+# Run stow
+RUN cd dotfiles && stow .
+
+# Set the default shell to zsh for the user
+RUN sudo chsh -s /usr/bin/zsh user
+
+# Set the default command to zsh
+CMD ["/bin/zsh"]

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -12,6 +12,7 @@ Key characteristics of this repository:
 - **Automated Setup**: An `install.sh` script is provided to automate the setup process, including installing Homebrew, required packages, and running `stow`.
 - **Manual Setup**: Manual installation instructions are also available for users who prefer more control.
 - **Zsh Plugins**: Zsh plugins are managed by `zinit` within the `.zshrc` file.
+- **Docker Image**: A `Dockerfile` is provided to create a containerized version of this environment. It is important to keep the `Dockerfile` and the `install.sh` script in sync. Any changes to dependencies or installation steps should be reflected in both files.
 
 When reviewing pull requests, please consider the following:
 - Changes should be consistent with the existing dotfile structure.

--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ This repository provides a Docker image with the complete environment pre-config
 
 2.  **Pull the Docker image from GHCR:**
     ```bash
-    docker pull ghcr.io/silverandroid/.files:latest
+    docker pull ghcr.io/silverandroid/dotfiles:latest
     ```
 
 3.  **Run the Docker container:**
     ```bash
-    docker run -d --name dotfiles ghcr.io/silverandroid/.files:latest
+    docker run -d --name dotfiles ghcr.io/silverandroid/dotfiles:latest
     ```
     This will start a container in detached mode with the name `dotfiles`.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,30 @@ The script will:
 *   Check for and install [Stow](https://www.gnu.org/software/stow/) if it's not already present.
 *   Run `stow .` from within the repository's root directory to create symbolic links (typically to your home directory, if you cloned to `~/dotfiles`).
 
+## Docker-based Installation (Recommended for VPS)
+
+This repository provides a Docker image with the complete environment pre-configured. This is the recommended way to set up the dotfiles on a new VPS.
+
+1.  **Install Docker:**
+    Ensure that Docker is installed on your system. You can follow the official Docker installation instructions for your OS.
+
+2.  **Pull the Docker image from GHCR:**
+    ```bash
+    docker pull ghcr.io/silverandroid/.files:latest
+    ```
+
+3.  **Run the Docker container:**
+    ```bash
+    docker run -it -d --name dotfiles ghcr.io/silverandroid/.files:latest
+    ```
+    This will start a container in detached mode with the name `dotfiles`.
+
+4.  **Connect to the container:**
+    ```bash
+    docker exec -it dotfiles /bin/zsh
+    ```
+    You will now be in a `zsh` shell with the complete environment set up.
+
 ## Manual Installation
 
 If you prefer to set things up manually, you will need to:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This repository provides a Docker image with the complete environment pre-config
 
 3.  **Run the Docker container:**
     ```bash
-    docker run -it -d --name dotfiles ghcr.io/silverandroid/.files:latest
+    docker run -d --name dotfiles ghcr.io/silverandroid/.files:latest
     ```
     This will start a container in detached mode with the name `dotfiles`.
 

--- a/install.sh
+++ b/install.sh
@@ -59,7 +59,7 @@ if command -v brew &> /dev/null; then
     echo "Using Homebrew to install packages..."
     brew install fzf
     brew install zoxide
-    brew install "openjdk@23"
+    brew install "openjdk@21"
     brew install bazelisk
     brew install nvm
     echo "Homebrew package installation attempt complete."

--- a/install.sh
+++ b/install.sh
@@ -91,16 +91,6 @@ fi
 # Create nvm directory, the nvm installer might create it, but -p makes it safe
 mkdir -p "$HOME/.nvm"
 
-# Zinit
-echo "Installing Zinit..."
-ZINIT_HOME="${XDG_DATA_HOME:-${HOME}/.local/share}/zinit/zinit.git"
-if [ ! -d "$ZINIT_HOME" ]; then
-   bash -c "$(curl --fail --show-error --silent --location https://raw.githubusercontent.com/zdharma-continuum/zinit/HEAD/scripts/install.sh)"
-   echo "Zinit installed."
-else
-   echo "Zinit is already installed."
-fi
-
 # --- End Fallbacks & Other Tools ---
 
 # --- Ubuntu Specific Setup ---
@@ -157,9 +147,6 @@ if is_ubuntu; then
 fi
 # --- End Ubuntu Specific Setup ---
 
-# --- Install Oh My Posh ---
-curl -s https://ohmyposh.dev/install.sh | bash -s
-
 # --- Check and Install Stow ---
 echo "Checking for Stow..."
 if ! command -v stow &> /dev/null; then
@@ -213,5 +200,18 @@ else
     fi
 fi
 # --- End Run Stow ---
+
+# --- Install Zinit ---
+echo "Installing Zinit..."
+ZINIT_HOME="${XDG_DATA_HOME:-${HOME}/.local/share}/zinit/zinit.git"
+if [ ! -d "$ZINIT_HOME" ]; then
+   bash -c "$(curl --fail --show-error --silent --location https://raw.githubusercontent.com/zdharma-continuum/zinit/HEAD/scripts/install.sh)"
+   echo "Zinit installed."
+else
+   echo "Zinit is already installed."
+fi
+
+# --- Install Oh My Posh ---
+curl -s https://ohmyposh.dev/install.sh | bash -s
 
 # (Rest of the script will follow)


### PR DESCRIPTION
This commit introduces a Dockerfile to containerize the dotfiles environment, simplifying setup on VPS providers like Linode.

Key changes:
- A `Dockerfile` is added, replicating the setup logic from `install.sh` for a consistent and reproducible environment.
- A new GitHub Actions workflow (`docker-publish.yml`) is created to automatically build and push the Docker image to the GitHub Container Registry (GHCR) on pushes to the main branch.
- The `README.md` is updated with a new "Docker-based Installation" section, providing instructions on how to pull and run the image.
- `GEMINI.md` is updated to include a reminder to keep the `Dockerfile` and `install.sh` synchronized.